### PR TITLE
Failure on Windows when getting default user

### DIFF
--- a/lice/core.py
+++ b/lice/core.py
@@ -5,6 +5,7 @@ import re
 import os
 import subprocess
 import sys
+import getpass
 
 __version__ = "0.2"
 
@@ -43,7 +44,7 @@ def guess_organization():
         stdout = subprocess.check_output('git config --get user.name'.split())
         org = stdout.strip()
     except OSError:
-        org = os.environ["USER"]
+        org = getpass.getuser()
     return org
 
 


### PR DESCRIPTION
On windows I get the following error:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lice\core.py", line 103, in main
    parser.add_argument('-o', '--org', dest='organization', default=guess_organization(),
  File "lice\core.py", line 46, in guess_organization
    org = os.environ["USER"]
  File "C:\Python27\lib\os.py", line 423, in **getitem**
    return self.data[key.upper()]
KeyError: 'USER'

I've tried to fix this by using the [getpass](http://docs.python.org/2/library/getpass.html#getpass.getuser) module instead.
