### PR TITLE
Replace unicode license text with ASCII

### DIFF
--- a/lice/template-gpl3.txt
+++ b/lice/template-gpl3.txt
@@ -1,594 +1,635 @@
-GNU GENERAL PUBLIC LICENSE
-Version 3, 29 June 2007
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
+                            Preamble
 
-Preamble
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-The GNU General Public License is a free, copyleft license for software
-and other kinds of works.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
-The licenses for most software and other practical works are designed to
-take away your freedom to share and change the works. By contrast, the
-GNU General Public License is intended to guarantee your freedom to share
-and change all versions of a program--to make sure it remains free software
-for all its users. We, the Free Software Foundation, use the GNU General
-Public License for most of our software; it applies also to any other work
-released this way by its authors. You can apply it to your programs, too.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-When we speak of free software, we are referring to freedom, not price.
-Our General Public Licenses are designed to make sure that you have the
-freedom to distribute copies of free software (and charge for them if
-you wish), that you receive source code or can get it if you want it, that
-you can change the software or use pieces of it in new free programs,
-and that you know you can do these things.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-To protect your rights, we need to prevent others from denying you these
-rights or asking you to surrender the rights. Therefore, you have certain
-responsibilities if you distribute copies of the software, or if you modify it:
-responsibilities to respect the freedom of others.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-For example, if you distribute copies of such a program, whether gratis or
-for a fee, you must pass on to the recipients the same freedoms that
-you received. You must make sure that they, too, receive or can get the
-source code. And you must show them these terms so they know their rights.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-Developers that use the GNU GPL protect your rights with two steps: (1) assert
-copyright on the software, and (2) offer you this License giving you legal
-permission to copy, distribute and/or modify it.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-For the developers' and authors' protection, the GPL clearly explains that
-there is no warranty for this free software. For both users' and authors' sake,
-the GPL requires that modified versions be marked as changed, so that their
-problems will not be attributed erroneously to authors of previous versions.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
 
-Some devices are designed to deny users access to install or run modified
-versions of the software inside them, although the manufacturer can do so.
-This is fundamentally incompatible with the aim of protecting users' freedom
-to change the software. The systematic pattern of such abuse occurs in the
-area of products for individuals to use, which is precisely where it is most
-unacceptable. Therefore, we have designed this version of the GPL to prohibit
-the practice for those products. If such problems arise substantially in other
-domains, we stand ready to extend this provision to those domains in future
-versions of the GPL, as needed to protect the freedom of users.
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
-Finally, every program is threatened constantly by software patents. States
-should not allow patents to restrict development and use of software on
-general-purpose computers, but in those that do, we wish to avoid the special
-danger that patents applied to a free program could make it effectively
-proprietary. To prevent this, the GPL assures that patents cannot be used
-to render the program non-free.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-The precise terms and conditions for copying, distribution
-and modification follow.
+                       TERMS AND CONDITIONS
 
-TERMS AND CONDITIONS
+  0. Definitions.
 
-0. Definitions.
+  "This License" refers to version 3 of the GNU General Public License.
 
-“This License” refers to version 3 of the GNU General Public License.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-“Copyright” also means copyright-like laws that apply to other kinds of works,
-such as semiconductor masks.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-“The Program” refers to any copyrightable work licensed under this License.
-Each licensee is addressed as “you”. “Licensees” and “recipients” may be
-individuals or organizations.
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-To “modify” a work means to copy from or adapt all or part of the work in a
-fashion requiring copyright permission, other than the making of an exact copy.
-The resulting work is called a “modified version” of the earlier work or a work
-“based on” the earlier work.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-A “covered work” means either the unmodified Program or a work
-based on the Program.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-To “propagate” a work means to do anything with it that, without permission,
-would make you directly or secondarily liable for infringement under applicable
-copyright law, except executing it on a computer or modifying a private copy.
-Propagation includes copying, distribution (with or without modification),
-making available to the public, and in some countries other activities as well.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-To “convey” a work means any kind of propagation that enables other parties
-to make or receive copies. Mere interaction with a user through a computer
-network, with no transfer of a copy, is not conveying.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-An interactive user interface displays “Appropriate Legal Notices” to the
-extent that it includes a convenient and prominently visible feature that
-(1) displays an appropriate copyright notice, and (2) tells the user that
-there is no warranty for the work (except to the extent that warranties are
-provided), that licensees may convey the work under this License, and how to
-view a copy of this License. If the interface presents a list of user commands
-or options, such as a menu, a prominent item in the list meets this criterion.
+  1. Source Code.
 
-1. Source Code.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-The “source code” for a work means the preferred form of the work for making
-modifications to it. “Object code” means any non-source form of a work.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-A “Standard Interface” means an interface that either is an official standard
-defined by a recognized standards body, or, in the case of interfaces specified
-for a particular programming language, one that is widely used among
-developers working in that language.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-The “System Libraries” of an executable work include anything, other than the
-work as a whole, that (a) is included in the normal form of packaging a
-Major Component, but which is not part of that Major Component, and (b) serves
-only to enable use of the work with that Major Component, or to implement a
-Standard Interface for which an implementation is available to the public in
-source code form. A “Major Component”, in this context, means a major essential
-component (kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to produce
-the work, or an object code interpreter used to run it.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-The “Corresponding Source” for a work in object code form means all the source
-code needed to generate, install, and (for an executable work) run the object
-code and to modify the work, including scripts to control those activities.
-However, it does not include the work's System Libraries, or general-purpose
-tools or generally available free programs which are used unmodified in
-performing those activities but which are not part of the work. For example,
-Corresponding Source includes interface definition files associated with
-source files for the work, and the source code for shared libraries and
-dynamically linked subprograms that the work is specifically designed to
-require, such as by intimate data communication or control flow between
-those subprograms and other parts of the work.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-The Corresponding Source need not include anything that users can regenerate
-automatically from other parts of the Corresponding Source.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-The Corresponding Source for a work in source code form is that same work.
+  2. Basic Permissions.
 
-2. Basic Permissions.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-All rights granted under this License are granted for the term of copyright
-on the Program, and are irrevocable provided the stated conditions are met.
-This License explicitly affirms your unlimited permission to run the
-unmodified Program. The output from running a covered work is covered by
-this License only if the output, given its content, constitutes a covered work.
-This License acknowledges your rights of fair use or other equivalent,
-as provided by copyright law.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-You may make, run and propagate covered works that you do not convey, without
-conditions so long as your license otherwise remains in force. You may convey
-covered works to others for the sole purpose of having them make modifications
-exclusively for you, or provide you with facilities for running those works,
-provided that you comply with the terms of this License in conveying all
-material for which you do not control copyright. Those thus making or running
-the covered works for you must do so exclusively on your behalf, under your
-direction and control, on terms that prohibit them from making any copies
-of your copyrighted material outside their relationship with you.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-Conveying under any other circumstances is permitted solely under the
-conditions stated below. Sublicensing is not allowed;
-section 10 makes it unnecessary.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-No covered work shall be deemed part of an effective technological measure
-under any applicable law fulfilling obligations under article 11 of the WIPO
-copyright treaty adopted on 20 December 1996, or similar laws prohibiting or
-restricting circumvention of such measures.
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention is
-effected by exercising rights under this License with respect to the covered
-work, and you disclaim any intention to limit operation or modification of
-the work as a means of enforcing, against the work's users, your or third
-parties' legal rights to forbid circumvention of technological measures.
+  4. Conveying Verbatim Copies.
 
-4. Conveying Verbatim Copies.
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
 
-You may convey verbatim copies of the Program's source code as you receive it,
-in any medium, provided that you conspicuously and appropriately publish on
-each copy an appropriate copyright notice; keep intact all notices stating
-that this License and any non-permissive terms added in accord with section 7
-apply to the code; keep intact all notices of the absence of any warranty;
-and give all recipients a copy of this License along with the Program.
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-You may charge any price or no price for each copy that you convey, and you
-may offer support or warranty protection for a fee.
+  5. Conveying Modified Source Versions.
 
-5. Conveying Modified Source Versions.
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
 
-You may convey a work based on the Program, or the modifications to produce
-it from the Program, in the form of source code under the terms of section 4,
-provided that you also meet all of these conditions:
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-    a) The work must carry prominent notices stating that you modified it,
-    and giving a relevant date.
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-    b) The work must carry prominent notices stating that it is released under
-    this License and any conditions added under section 7. This requirement
-    modifies the requirement in section 4 to “keep intact all notices”.
-
-    c) You must license the entire work, as a whole, under this License to
-    anyone who comes into possession of a copy. This License will therefore
-    apply, along with any applicable section 7 additional terms, to the whole
-    of the work, and all its parts, regardless of how they are packaged.
-    This License gives no permission to license the work in any other way,
-    but it does not invalidate such permission if you
-    have separately received it.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
     d) If the work has interactive user interfaces, each must display
     Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your work
-    need not make them do so.
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-A compilation of a covered work with other separate and independent works,
-which are not by their nature extensions of the covered work, and which are
-not combined with it such as to form a larger program, in or on a volume of
-a storage or distribution medium, is called an “aggregate” if the compilation
-and its resulting copyright are not used to limit the access or legal rights
-of the compilation's users beyond what the individual works permit. Inclusion
-of a covered work in an aggregate does not cause this License to apply to
-the other parts of the aggregate.
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
 
-6. Conveying Non-Source Forms.
+  6. Conveying Non-Source Forms.
 
-You may convey a covered work in object code form under the terms of
-sections 4 and 5, provided that you also convey the machine-readable
-Corresponding Source under the terms of this License, in one of these ways:
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
 
     a) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium customarily
-    used for software interchange.
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
     b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a written offer,
-    valid for at least three years and valid for as long as you offer spare
-    parts or customer support for that product model, to give anyone who
-    possesses the object code either (1) a copy of the Corresponding Source
-    for all the software in the product that is covered by this License, on a
-    durable physical medium customarily used for software interchange, for a
-    price no more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the Corresponding Source from
-    a network server at no charge.
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-    c) Convey individual copies of the object code with a copy of the written
-    offer to provide the Corresponding Source. This alternative is allowed
-    only occasionally and noncommercially, and only if you received the object
-    code with such an offer, in accord with subsection 6b.
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-    d) Convey the object code by offering access from a designated place
-    (gratis or for a charge), and offer equivalent access to the Corresponding
-    Source in the same way through the same place at no further charge.
-    You need not require recipients to copy the Corresponding Source along
-    with the object code. If the place to copy the object code is a network
-    server, the Corresponding Source may be on a different server (operated
-    by you or a third party) that supports equivalent copying facilities,
-    provided you maintain clear directions next to the object code saying
-    where to find the Corresponding Source. Regardless of what server hosts
-    the Corresponding Source, you remain obligated to ensure that it is
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
     available for as long as needed to satisfy these requirements.
 
-    e) Convey the object code using peer-to-peer transmission, provided you
-    inform other peers where the object code and Corresponding Source of the
-    work are being offered to the general public at no charge
-    under subsection 6d.
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
 
-A separable portion of the object code, whose source code is excluded from the
-Corresponding Source as a System Library, need not be included in conveying
-the object code work.
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
 
-A “User Product” is either (1) a “consumer product”, which means any tangible
-personal property which is normally used for personal, family, or household
-purposes, or (2) anything designed or sold for incorporation into a dwelling.
-In determining whether a product is a consumer product, doubtful cases shall
-be resolved in favor of coverage. For a particular product received by a
-particular user, “normally used” refers to a typical or common use of that
-class of product, regardless of the status of the particular user or of the
-way in which the particular user actually uses, or expects or is expected
-to use, the product. A product is a consumer product regardless of whether
-the product has substantial commercial, industrial or non-consumer uses,
-unless such uses represent the only significant mode of use of the product.
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
 
-“Installation Information” for a User Product means any methods, procedures,
-authorization keys, or other information required to install and execute
-modified versions of a covered work in that User Product from a modified
-version of its Corresponding Source. The information must suffice to ensure
-that the continued functioning of the modified object code is in no case
-prevented or interfered with solely because modification has been made.
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
 
-If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as part of
-a transaction in which the right of possession and use of the User Product
-is transferred to the recipient in perpetuity or for a fixed term (regardless
-of how the transaction is characterized), the Corresponding Source conveyed
-under this section must be accompanied by the Installation Information.
-But this requirement does not apply if neither you nor any third party retains
-the ability to install modified object code on the User Product (for example,
-the work has been installed in ROM).
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
 
-The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates for
-a work that has been modified or installed by the recipient, or for the User
-Product in which it has been modified or installed. Access to a network may
-be denied when the modification itself materially and adversely affects the
-operation of the network or violates the rules and protocols for
-communication across the network.
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
 
-Corresponding Source conveyed, and Installation Information provided, in
-accord with this section must be in a format that is publicly documented
-(and with an implementation available to the public in source code form),
-and must require no special password or key for unpacking, reading or copying.
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
 
-7. Additional Terms.
+  7. Additional Terms.
 
-“Additional permissions” are terms that supplement the terms of this License
-by making exceptions from one or more of its conditions. Additional permissions
-that are applicable to the entire Program shall be treated as though they were
-included in this License, to the extent that they are valid under applicable
-law. If additional permissions apply only to part of the Program, that part
-may be used separately under those permissions, but the entire Program remains
-governed by this License without regard to the additional permissions.
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
 
-When you convey a copy of a covered work, you may at your option remove any
-additional permissions from that copy, or from any part of it. (Additional
-permissions may be written to require their own removal in certain cases
-when you modify the work.) You may place additional permissions on material,
-added by you to a covered work, for which you have or can give
-appropriate copyright permission.
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
 
-Notwithstanding any other provision of this License, for material you add to a
-covered work, you may (if authorized by the copyright holders of that material)
-supplement the terms of this License with terms:
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
 
-    a) Disclaiming warranty or limiting liability differently from the terms
-    of sections 15 and 16 of this License; or
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
 
-    b) Requiring preservation of specified reasonable legal notices or author
-    attributions in that material or in the Appropriate Legal Notices displayed
-    by works containing it; or
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
 
     c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in reasonable
-    ways as different from the original version; or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
 
     d) Limiting the use for publicity purposes of names of licensors or
     authors of the material; or
 
-    e) Declining to grant rights under trademark law for use of some trade
-    names, trademarks, or service marks; or
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
 
-    f) Requiring indemnification of licensors and authors of that material
-    by anyone who conveys the material (or modified versions of it) with
-    contractual assumptions of liability to the recipient, for any liability
-    that these contractual assumptions directly impose on those
-    licensors and authors.
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
 
-All other non-permissive additional terms are considered “further restrictions”
-within the meaning of section 10. If the Program as you received it, or any
-part of it, contains a notice stating that it is governed by this License
-along with a term that is a further restriction, you may remove that term.
-If a license document contains a further restriction but permits relicensing
-or conveying under this License, you may add to a covered work material
-governed by the terms of that license document, provided that the further
-restriction does not survive such relicensing or conveying.
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
 
-If you add terms to a covered work in accord with this section, you must place,
-in the relevant source files, a statement of the additional terms that apply
-to those files, or a notice indicating where to find the applicable terms.
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
 
-Additional terms, permissive or non-permissive, may be stated in the form of
-a separately written license, or stated as exceptions; the above
-requirements apply either way.
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
 
-8. Termination.
+  8. Termination.
 
-You may not propagate or modify a covered work except as expressly provided
-under this License. Any attempt otherwise to propagate or modify it is void,
-and will automatically terminate your rights under this License (including
-any patent licenses granted under the third paragraph of section 11).
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
 
-However, if you cease all violation of this License, then your license from a
-particular copyright holder is reinstated (a) provisionally, unless and until
-the copyright holder explicitly and finally terminates your license, and
-(b) permanently, if the copyright holder fails to notify you of the violation
-by some reasonable means prior to 60 days after the cessation.
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
 
-Moreover, your license from a particular copyright holder is reinstated
-permanently if the copyright holder notifies you of the violation by some
-reasonable means, this is the first time you have received notice of violation
-of this License (for any work) from that copyright holder, and you cure the
-violation prior to 30 days after your receipt of the notice.
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
 
-Termination of your rights under this section does not terminate the licenses
-of parties who have received copies or rights from you under this License.
-If your rights have been terminated and not permanently reinstated, you do
-not qualify to receive new licenses for the same material under section 10.
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
 
-9. Acceptance Not Required for Having Copies.
+  9. Acceptance Not Required for Having Copies.
 
-You are not required to accept this License in order to receive or run a copy
-of the Program. Ancillary propagation of a covered work occurring solely as
-a consequence of using peer-to-peer transmission to receive a copy likewise
-does not require acceptance. However, nothing other than this License grants
-you permission to propagate or modify any covered work. These actions infringe
-copyright if you do not accept this License. Therefore, by modifying or
-propagating a covered work, you indicate your acceptance
-of this License to do so.
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
 
-10. Automatic Licensing of Downstream Recipients.
+  10. Automatic Licensing of Downstream Recipients.
 
-Each time you convey a covered work, the recipient automatically receives a
-license from the original licensors, to run, modify and propagate that work,
-subject to this License. You are not responsible for enforcing compliance
-by third parties with this License.
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
 
-An “entity transaction” is a transaction transferring control of an
+  An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations. If propagation of a covered work
-results from an entity transaction, each party to that transaction who receives
-a copy of the work also receives whatever licenses to the work the party's
-predecessor in interest had or could give under the previous paragraph, plus a
-right to possession of the Corresponding Source of the work from the
-predecessor in interest, if the predecessor has it or can get it
-with reasonable efforts.
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
 
-You may not impose any further restrictions on the exercise of the rights
-granted or affirmed under this License. For example, you may not impose a
-license fee, royalty, or other charge for exercise of rights granted under
-this License, and you may not initiate litigation (including a cross-claim
-or counterclaim in a lawsuit) alleging that any patent claim is infringed
-by making, using, selling, offering for sale, or importing the Program
-or any portion of it.
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
 
-11. Patents.
+  11. Patents.
 
-A “contributor” is a copyright holder who authorizes use under this License
-of the Program or a work on which the Program is based. The work thus licensed
-is called the contributor's “contributor version”.
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
 
-A contributor's “essential patent claims” are all patent claims owned or
-controlled by the contributor, whether already acquired or hereafter acquired,
-that would be infringed by some manner, permitted by this License, of making,
-using, or selling its contributor version, but do not include claims that
-would be infringed only as a consequence of further modification of the
-contributor version. For purposes of this definition, “control” includes
-the right to grant patent sublicenses in a manner consistent with the
-requirements of this License.
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
 
-Each contributor grants you a non-exclusive, worldwide, royalty-free patent
-license under the contributor's essential patent claims, to make, use, sell,
-offer for sale, import and otherwise run, modify and propagate the contents
-of its contributor version.
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
 
-In the following three paragraphs, a “patent license” is any express agreement
-or commitment, however denominated, not to enforce a patent (such as an
-express permission to practice a patent or covenant not to sue for patent
-infringement). To “grant” such a patent license to a party means to make such
-an agreement or commitment not to enforce a patent against the party.
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
 
-If you convey a covered work, knowingly relying on a patent license, and the
-Corresponding Source of the work is not available for anyone to copy, free of
-charge and under the terms of this License, through a publicly available
-network server or other readily accessible means, then you must either
-(1) cause the Corresponding Source to be so available, or (2) arrange to
-deprive yourself of the benefit of the patent license for this particular work,
-or (3) arrange, in a manner consistent with the requirements of this License,
-to extend the patent license to downstream recipients. “Knowingly relying”
-means you have actual knowledge that, but for the patent license, your
-conveying the covered work in a country, or your recipient's use of the
-covered work in a country, would infringe one or more identifiable patents
-in that country that you have reason to believe are valid.
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
 
-If, pursuant to or in connection with a single transaction or arrangement,
-you convey, or propagate by procuring conveyance of, a covered work, and
-grant a patent license to some of the parties receiving the covered work
-authorizing them to use, propagate, modify or convey a specific copy of the
-covered work, then the patent license you grant is automatically extended
-to all recipients of the covered work and works based on it.
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
 
-A patent license is “discriminatory” if it does not include within the scope
-of its coverage, prohibits the exercise of, or is conditioned on the
-non-exercise of one or more of the rights that are specifically granted under
-this License. You may not convey a covered work if you are a party to an
-arrangement with a third party that is in the business of distributing
-software, under which you make payment to the third party based on the extent
-of your activity of conveying the work, and under which the third party grants,
-to any of the parties who would receive the covered work from you, a
-discriminatory patent license (a) in connection with copies of the covered
-work conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that contain
-the covered work, unless you entered into that arrangement, or that patent
-license was granted, prior to 28 March 2007.
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
 
-Nothing in this License shall be construed as excluding or limiting any
-implied license or other defenses to infringement that may otherwise be
-available to you under applicable patent law.
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
 
-12. No Surrender of Others' Freedom.
+  12. No Surrender of Others' Freedom.
 
-If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not excuse
-you from the conditions of this License. If you cannot convey a covered work
-so as to satisfy simultaneously your obligations under this License and any
-other pertinent obligations, then as a consequence you may not convey it
-at all. For example, if you agree to terms that obligate you to collect a
-royalty for further conveying from those to whom you convey the Program,
-the only way you could satisfy both those terms and this License would be
-to refrain entirely from conveying the Program.
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
 
-13. Use with the GNU Affero General Public License.
+  13. Use with the GNU Affero General Public License.
 
-Notwithstanding any other provision of this License, you have permission to
-link or combine any covered work with a work licensed under version 3 of the
-GNU Affero General Public License into a single combined work, and to convey
-the resulting work. The terms of this License will continue to apply to the
-part which is the covered work, but the special requirements of the
-GNU Affero General Public License, section 13, concerning interaction through
-a network will apply to the combination as such.
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
-14. Revised Versions of this License.
+  14. Revised Versions of this License.
 
-The Free Software Foundation may publish revised and/or new versions of the
-GNU General Public License from time to time. Such new versions will be similar
-in spirit to the present version, but may differ in detail to address
-new problems or concerns.
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
 
-Each version is given a distinguishing version number. If the Program
-specifies that a certain numbered version of the GNU General Public License
-“or any later version” applies to it, you have the option of following the
-terms and conditions either of that numbered version or of any later version
-published by the Free Software Foundation. If the Program does not specify a
-version number of the GNU General Public License, you may choose any version
-ever published by the Free Software Foundation.
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-If the Program specifies that a proxy can decide which future versions of the
-GNU General Public License can be used, that proxy's public statement of
-acceptance of a version permanently authorizes you to choose that
-version for the Program.
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-Later license versions may give you additional or different permissions.
-However, no additional obligations are imposed on any author or copyright
-holder as a result of your choosing to follow a later version.
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
 
-15. Disclaimer of Warranty.
+  15. Disclaimer of Warranty.
 
-THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE
-LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
-PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER
-EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO
-THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM
-PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-16. Limitation of Liability.
+  16. Limitation of Liability.
 
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
-ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE
-PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE
-OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA
-OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES
-OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
-SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
 
-17. Interpretation of Sections 15 and 16.
+  17. Interpretation of Sections 15 and 16.
 
-If the disclaimer of warranty and limitation of liability provided above
-cannot be given local legal effect according to their terms, reviewing courts
-shall apply local law that most closely approximates an absolute waiver of
-all civil liability in connection with the Program, unless a warranty or
-assumption of liability accompanies a copy of the Program in return for a fee.
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
 
-END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
-How to Apply These Terms to Your New Programs
+            How to Apply These Terms to Your New Programs
 
-If you develop a new program, and you want it to be of the greatest possible
-use to the public, the best way to achieve this is to make it free software
-which everyone can redistribute and change under these terms.
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
 
-To do so, attach the following notices to the program. It is safest to attach
-them to the start of each source file to most effectively state the exclusion
-of warranty; and each file should have at least the “copyright” line and a
-pointer to where the full notice is found.
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) {{ year }}  {{ organization }}
@@ -608,27 +649,26 @@ pointer to where the full notice is found.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program does terminal interaction, make it output a short notice like
-this when it starts in an interactive mode:
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
     {{ project }}  Copyright (C) {{ year }}  {{ organization }}
-
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License. Of course, your program's commands
-might be different; for a GUI interface, you would use an “about box”.
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or school,
-if any, to sign a “copyright disclaimer” for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL,
-see <http://www.gnu.org/licenses/>.
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
 
-The GNU General Public License does not permit incorporating your program
-into proprietary programs. If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library. If this is what you want to do, use the GNU Lesser General Public
-License instead of this License.
-But first, please read <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/lice/template-lgpl.txt
+++ b/lice/template-lgpl.txt
@@ -1,155 +1,165 @@
-GNU LESSER GENERAL PUBLIC LICENSE
-Version 3, 29 June 2007
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
 
-This version of the GNU Lesser General Public License incorporates the terms
-and conditions of version 3 of the GNU General Public License, supplemented
-by the additional permissions listed below.
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
 
-0. Additional Definitions.
+  0. Additional Definitions.
 
-As used herein, “this License” refers to version 3 of the GNU Lesser General
-Public License, and the “GNU GPL” refers to version 3 of the
-GNU General Public License.
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
 
-“The Library” refers to a covered work governed by this License, other than
-an Application or a Combined Work as defined below.
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
 
-An “Application” is any work that makes use of an interface provided by the
-Library, but which is not otherwise based on the Library. Defining a subclass
-of a class defined by the Library is deemed a mode of using an interface
-provided by the Library.
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
 
-A “Combined Work” is a work produced by combining or linking an Application
-with the Library. The particular version of the Library with which the
-Combined Work was made is also called the “Linked Version”.
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
 
-The “Minimal Corresponding Source” for a Combined Work means the Corresponding
-Source for the Combined Work, excluding any source code for portions of the
-Combined Work that, considered in isolation, are based on the Application,
-and not on the Linked Version.
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
 
-The “Corresponding Application Code” for a Combined Work means the object code
-and/or source code for the Application, including any data and utility programs
-needed for reproducing the Combined Work from the Application, but excluding
-the System Libraries of the Combined Work.
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
 
-1. Exception to Section 3 of the GNU GPL.
+  1. Exception to Section 3 of the GNU GPL.
 
-You may convey a covered work under sections 3 and 4 of this License without
-being bound by section 3 of the GNU GPL.
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
 
-2. Conveying Modified Versions.
+  2. Conveying Modified Versions.
 
-If you modify a copy of the Library, and, in your modifications, a facility
-refers to a function or data to be supplied by an Application that uses the
-facility (other than as an argument passed when the facility is invoked),
-then you may convey a copy of the modified version:
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
 
-    a) under this License, provided that you make a good faith effort to
-    ensure that, in the event an Application does not supply the function or
-    data, the facility still operates, and performs whatever part of its
-    purpose remains meaningful, or
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
 
-    b) under the GNU GPL, with none of the additional permissions of this
-    License applicable to that copy.
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
 
-3. Object Code Incorporating Material from Library Header Files.
+  3. Object Code Incorporating Material from Library Header Files.
 
-The object code form of an Application may incorporate material from a header
-file that is part of the Library. You may convey such object code under terms
-of your choice, provided that, if the incorporated material is not limited to
-numerical parameters, data structure layouts and accessors, or small macros,
-inline functions and templates (ten or fewer lines in length),
-you do both of the following:
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
 
-    a) Give prominent notice with each copy of the object code that the Library
-    is used in it and that the Library and its use are covered by this License.
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
 
-    b) Accompany the object code with a copy of the GNU GPL
-    and this license document.
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
 
-4. Combined Works.
+  4. Combined Works.
 
-You may convey a Combined Work under terms of your choice that, taken together,
-effectively do not restrict modification of the portions of the Library
-contained in the Combined Work and reverse engineering for debugging such
-modifications, if you also do each of the following:
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
 
-    a) Give prominent notice with each copy of the Combined Work that the
-    Library is used in it and that the Library and its use are covered
-    by this License.
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
 
-    b) Accompany the Combined Work with a copy of the GNU GPL and
-    this license document.
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
 
-    c) For a Combined Work that displays copyright notices during execution,
-    include the copyright notice for the Library among these notices, as well
-    as a reference directing the user to the copies of the GNU GPL
-    and this license document.
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
 
-    d) Do one of the following:
+   d) Do one of the following:
 
-        0) Convey the Minimal Corresponding Source under the terms of this
-        License, and the Corresponding Application Code in a form suitable
-        for, and under terms that permit, the user to recombine or relink
-        the Application with a modified version of the Linked Version to
-        produce a modified Combined Work, in the manner specified by section 6
-        of the GNU GPL for conveying Corresponding Source.
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
 
-        1) Use a suitable shared library mechanism for linking with the
-        Library. A suitable mechanism is one that (a) uses at run time a
-        copy of the Library already present on the user's computer system,
-        and (b) will operate properly with a modified version of the Library
-        that is interface-compatible with the Linked Version.
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
 
-    e) Provide Installation Information, but only if you would otherwise be
-    required to provide such information under section 6 of the GNU GPL, and
-    only to the extent that such information is necessary to install and
-    execute a modified version of the Combined Work produced by recombining
-    or relinking the Application with a modified version of the Linked Version.
-    (If you use option 4d0, the Installation Information must accompany the
-    Minimal Corresponding Source and Corresponding Application Code. If you
-    use option 4d1, you must provide the Installation Information in the
-    manner specified by section 6 of the GNU GPL for
-    conveying Corresponding Source.)
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
 
-5. Combined Libraries.
+  5. Combined Libraries.
 
-You may place library facilities that are a work based on the Library side by
-side in a single library together with other library facilities that are not
-Applications and are not covered by this License, and convey such a combined
-library under terms of your choice, if you do both of the following:
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
 
-    a) Accompany the combined library with a copy of the same work based on
-    the Library, uncombined with any other library facilities, conveyed under
-    the terms of this License.
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
 
-    b) Give prominent notice with the combined library that part of it is a
-    work based on the Library, and explaining where to find the accompanying
-    uncombined form of the same work.
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
 
-6. Revised Versions of the GNU Lesser General Public License.
+  6. Revised Versions of the GNU Lesser General Public License.
 
-The Free Software Foundation may publish revised and/or new versions of the
-GNU Lesser General Public License from time to time. Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
 
-Each version is given a distinguishing version number. If the Library as you
-received it specifies that a certain numbered version of the GNU Lesser
-General Public License “or any later version” applies to it, you have the
-option of following the terms and conditions either of that published version
-or of any later version published by the Free Software Foundation. If the
-Library as you received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser General
-Public License ever published by the Free Software Foundation.
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
 
-If the Library as you received it specifies that a proxy can decide whether
-future versions of the GNU Lesser General Public License shall apply, that
-proxy's public statement of acceptance of any version is permanent
-authorization for you to choose that version for the Library.
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/lice/template-mpl.txt
+++ b/lice/template-mpl.txt
@@ -1,328 +1,373 @@
-Mozilla Public License, version 2.0
+Mozilla Public License Version 2.0
+==================================
 
 1. Definitions
+--------------
 
-    1.1. “Contributor”
-    means each individual or legal entity that creates, contributes to the
-    creation of, or owns Covered Software.
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
 
-    1.2. “Contributor Version”
-    means the combination of the Contributions of others (if any) used by a
-    Contributor and that particular Contributor’s Contribution.
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
 
-    1.3. “Contribution”
+1.3. "Contribution"
     means Covered Software of a particular Contributor.
 
-    1.4. “Covered Software”
-    means Source Code Form to which the initial Contributor has attached the
-    notice in Exhibit A, the Executable Form of such Source Code Form,
-    and Modifications of such Source Code Form, in each case
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
     including portions thereof.
 
-    1.5. “Incompatible With Secondary Licenses”
+1.5. "Incompatible With Secondary Licenses"
     means
 
-        a. that the initial Contributor has attached the notice described
+    (a) that the initial Contributor has attached the notice described
         in Exhibit B to the Covered Software; or
 
-        b. that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the terms
-        of a Secondary License.
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
 
-    1.6. “Executable Form”
+1.6. "Executable Form"
     means any form of the work other than Source Code Form.
 
-    1.7. “Larger Work”
-    means a work that combines Covered Software with other material,
-    in a separate file or files, that is not Covered Software.
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
 
-    1.8. “License”
+1.8. "License"
     means this document.
 
-    1.9. “Licensable”
+1.9. "Licensable"
     means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently,
-    any and all of the rights conveyed by this License.
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
 
-    1.10. “Modifications”
+1.10. "Modifications"
     means any of the following:
 
-        a. any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered Software; or
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
 
-        b. any new file in Source Code Form that contains any Covered Software.
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
 
-    1.11. “Patent Claims” of a Contributor
-    means any patent claim(s), including without limitation, method, process,
-    and apparatus claims, in any patent Licensable by such Contributor that
-    would be infringed, but for the grant of the License, by the making,
-    using, selling, offering for sale, having made, import, or transfer of
-    either its Contributions or its Contributor Version.
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
 
-    1.12. “Secondary License”
-    means either the GNU General Public License, Version 2.0, the
-    GNU Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those licenses.
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
 
-    1.13. “Source Code Form”
+1.13. "Source Code Form"
     means the form of the work preferred for making modifications.
 
-    1.14. “You” (or “Your”)
-    means an individual or a legal entity exercising rights under this License.
-    For legal entities, “You” includes any entity that controls,
-    is controlled by, or is under common control with You. For purposes of
-    this definition, “control” means (a) the power, direct or indirect,
-    to cause the direction or management of such entity, whether by contract
-    or otherwise, or (b) ownership of more than fifty percent (50%) of the
-    outstanding shares or beneficial ownership of such entity.
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
 
 2. License Grants and Conditions
+--------------------------------
 
-    2.1. Grants
-    Each Contributor hereby grants You a world-wide, royalty-free,
-    non-exclusive license:
+2.1. Grants
 
-        a. under intellectual property rights (other than patent or trademark)
-        Licensable by such Contributor to use, reproduce, make available,
-        modify, display, perform, distribute, and otherwise exploit its
-        Contributions, either on an unmodified basis, with Modifications,
-        or as part of a Larger Work; and
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
 
-        b. under Patent Claims of such Contributor to make, use, sell,
-        offer for sale, have made, import, and otherwise transfer either
-        its Contributions or its Contributor Version.
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
 
-    2.2. Effective Date
-    The licenses granted in Section 2.1 with respect to any Contribution
-    become effective for each Contribution on the date the Contributor
-    first distributes such Contribution.
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
 
-    2.3. Limitations on Grant Scope
-    The licenses granted in this Section 2 are the only rights granted
-    under this License. No additional rights or licenses will be implied
-    from the distribution or licensing of Covered Software under this License.
-    Notwithstanding Section 2.1(b) above, no patent license is granted
-    by a Contributor:
+2.2. Effective Date
 
-        a. for any code that a Contributor has removed from
-        Covered Software; or
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
 
-        b. for infringements caused by: (i) Your and any other third party’s
-        modifications of Covered Software, or (ii) the combination of its
-        Contributions with other software (except as part of its
-        Contributor Version); or
+2.3. Limitations on Grant Scope
 
-        c. under Patent Claims infringed by Covered Software in the
-        absence of its Contributions.
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
 
-    This License does not grant any rights in the trademarks, service marks,
-    or logos of any Contributor (except as may be necessary to comply with
-    the notice requirements in Section 3.4).
+(a) for any code that a Contributor has removed from Covered Software;
+    or
 
-    2.4. Subsequent Licenses
-    No Contributor makes additional grants as a result of Your choice to
-    distribute the Covered Software under a subsequent version of this
-    License (see Section 10.2) or under the terms of a Secondary License
-    (if permitted under the terms of Section 3.3).
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
 
-    2.5. Representation
-    Each Contributor represents that the Contributor believes its
-    Contributions are its original creation(s) or it has sufficient rights
-    to grant the rights to its Contributions conveyed by this License.
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
 
-    2.6. Fair Use
-    This License is not intended to limit any rights You have under
-    applicable copyright doctrines of fair use, fair dealing,
-    or other equivalents.
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
 
-    2.7. Conditions
-    Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the
-    licenses granted in Section 2.1.
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
 
 3. Responsibilities
+-------------------
 
-    3.1. Distribution of Source Form
-    All distribution of Covered Software in Source Code Form, including
-    any Modifications that You create or to which You contribute, must be
-    under the terms of this License. You must inform recipients that the
-    Source Code Form of the Covered Software is governed by the terms
-    of this License, and how they can obtain a copy of this License.
-    You may not attempt to alter or restrict the recipients’ rights
-    in the Source Code Form.
+3.1. Distribution of Source Form
 
-    3.2. Distribution of Executable Form
-    If You distribute Covered Software in Executable Form then:
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
 
-        a. such Covered Software must also be made available in Source Code
-        Form, as described in Section 3.1, and You must inform recipients of
-        the Executable Form how they can obtain a copy of such Source Code
-        Form by reasonable means in a timely manner, at a charge no more than
-        the cost of distribution to the recipient; and
+3.2. Distribution of Executable Form
 
-        b. You may distribute such Executable Form under the terms of this
-        License, or sublicense it under different terms, provided that the
-        license for the Executable Form does not attempt to limit or alter
-        the recipients’ rights in the Source Code Form under this License.
+If You distribute Covered Software in Executable Form then:
 
-    3.3. Distribution of a Larger Work
-    You may create and distribute a Larger Work under terms of Your choice,
-    provided that You also comply with the requirements of this License for
-    the Covered Software. If the Larger Work is a combination of
-    Covered Software with a work governed by one or more Secondary Licenses,
-    and the Covered Software is not Incompatible With Secondary Licenses,
-    this License permits You to additionally distribute such Covered Software
-    under the terms of such Secondary License(s), so that the recipient of
-    the Larger Work may, at their option, further distribute the
-    Covered Software under the terms of either this License or such
-    Secondary License(s).
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
 
-    3.4. Notices
-    You may not remove or alter the substance of any license notices
-    (including copyright notices, patent notices, disclaimers of warranty,
-    or limitations of liability) contained within the Source Code Form of
-    the Covered Software, except that You may alter any license notices to
-    the extent required to remedy known factual inaccuracies.
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
 
-    3.5. Application of Additional Terms
-    You may choose to offer, and to charge a fee for, warranty, support,
-    indemnity or liability obligations to one or more recipients of
-    Covered Software. However, You may do so only on Your own behalf,
-    and not on behalf of any Contributor. You must make it absolutely clear
-    that any such warranty, support, indemnity, or liability obligation is
-    offered by You alone, and You hereby agree to indemnify every Contributor
-    for any liability incurred by such Contributor as a result of warranty,
-    support, indemnity or liability terms You offer. You may include
-    additional disclaimers of warranty and limitations of liability
-    specific to any jurisdiction.
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
 
 4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
 
-If it is impossible for You to comply with any of the terms of this License
-with respect to some or all of the Covered Software due to statute,
-judicial order, or regulation then You must: (a) comply with the terms of
-this License to the maximum extent possible; and (b) describe the limitations
-and the code they affect. Such description must be placed in a text file
-included with all distributions of the Covered Software under this License.
-Except to the extent prohibited by statute or regulation, such description
-must be sufficiently detailed for a recipient of ordinary skill
-to be able to understand it.
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
 
 5. Termination
+--------------
 
-    5.1. The rights granted under this License will terminate automatically
-    if You fail to comply with any of its terms. However, if You become
-    compliant, then the rights granted under this License from a particular
-    Contributor are reinstated (a) provisionally, unless and until such
-    Contributor explicitly and finally terminates Your grants, and (b) on an
-    ongoing basis, if such Contributor fails to notify You of the
-    non-compliance by some reasonable means prior to 60 days after You have
-    come back into compliance. Moreover, Your grants from a particular
-    Contributor are reinstated on an ongoing basis if such Contributor
-    notifies You of the non-compliance by some reasonable means,
-    this is the first time You have received notice of non-compliance with
-    this License from such Contributor, and You become compliant prior to
-    30 days after Your receipt of the notice.
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
 
-    5.2. If You initiate litigation against any entity by asserting a patent
-    infringement claim (excluding declaratory judgment actions,
-    counter-claims, and cross-claims) alleging that a Contributor Version
-    directly or indirectly infringes any patent, then the rights granted
-    to You by any and all Contributors for the Covered Software under
-    Section 2.1 of this License shall terminate.
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
 
-    5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-    end user license agreements (excluding distributors and resellers) which
-    have been validly granted by You or Your distributors under this License
-    prior to termination shall survive termination.
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
 
-6. Disclaimer of Warranty
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
 
-Covered Software is provided under this License on an “as is” basis, without
-warranty of any kind, either expressed, implied, or statutory, including,
-without limitation, warranties that the Covered Software is free of defects,
-merchantable, fit for a particular purpose or non-infringing. The entire risk
-as to the quality and performance of the Covered Software is with You.
-Should any Covered Software prove defective in any respect, You
-(not any Contributor) assume the cost of any necessary servicing, repair,
-or correction. This disclaimer of warranty constitutes an essential part of
-this License. No use of any Covered Software is authorized under this
-License except under this disclaimer.
-
-7. Limitation of Liability
-
-Under no circumstances and under no legal theory, whether tort
-(including negligence), contract, or otherwise, shall any Contributor, or
-anyone who distributes Covered Software as permitted above, be liable to
-You for any direct, indirect, special, incidental, or consequential damages
-of any character including, without limitation, damages for lost profits,
-loss of goodwill, work stoppage, computer failure or malfunction, or any and
-all other commercial damages or losses, even if such party shall have been
-informed of the possibility of such damages. This limitation of liability
-shall not apply to liability for death or personal injury resulting from
-such party’s negligence to the extent applicable law prohibits such
-limitation. Some jurisdictions do not allow the exclusion or limitation of
-incidental or consequential damages, so this exclusion and limitation may
-not apply to You.
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
 
 8. Litigation
+-------------
 
-Any litigation relating to this License may be brought only in the courts of
-a jurisdiction where the defendant maintains its principal place of business
-and such litigation shall be governed by laws of that jurisdiction, without
-reference to its conflict-of-law provisions. Nothing in this Section shall
-prevent a party’s ability to bring cross-claims or counter-claims.
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
 
 9. Miscellaneous
+----------------
 
-This License represents the complete agreement concerning the subject matter
-hereof. If any provision of this License is held to be unenforceable,
-such provision shall be reformed only to the extent necessary to make it
-enforceable. Any law or regulation which provides that the language of a
-contract shall be construed against the drafter shall not be used to construe
-this License against a Contributor.
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
 
 10. Versions of the License
+---------------------------
 
-    10.1. New Versions
-    Mozilla Foundation is the license steward. Except as provided in
-    Section 10.3, no one other than the license steward has the right to
-    modify or publish new versions of this License. Each version will be
-    given a distinguishing version number.
+10.1. New Versions
 
-    10.2. Effect of New Versions
-    You may distribute the Covered Software under the terms of the version
-    of the License under which You originally received the Covered Software,
-    or under the terms of any subsequent version published
-    by the license steward.
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
 
-    10.3. Modified Versions
-    If you create software not governed by this License, and you want to
-    create a new license for such software, you may create and use a modified
-    version of this License if you rename the license and remove any
-    references to the name of the license steward (except to note that such
-    modified license differs from this License).
+10.2. Effect of New Versions
 
-    10.4. Distributing Source Code Form that is
-    Incompatible With Secondary Licenses
-    If You choose to distribute Source Code Form that is
-    Incompatible With Secondary Licenses under the terms of this version of
-    the License, the notice described in Exhibit B of this
-    License must be attached.
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
 
 Exhibit A - Source Code Form License Notice
+-------------------------------------------
 
-    This Source Code Form is subject to the terms of the
-    Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-    with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-If it is not possible or desirable to put the notice in a particular file,
-then You may include the notice in a location (such as a LICENSE file in a
-relevant directory) where a recipient would be likely to
-look for such a notice.
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
 
 You may add additional accurate notices of copyright ownership.
 
-Exhibit B - “Incompatible With Secondary Licenses” Notice
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
 
-    This Source Code Form is “Incompatible With Secondary Licenses”,
-    as defined by the Mozilla Public License, v. 2.0.
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.


### PR DESCRIPTION
Some license files were in unicode, which caused lice to crash with
input like `lice gpl3 >LICENSE` as the unicode would fail to decode to
ascii.

I have pulled the official ASCII versions of each affected license from
the official sites:

https://www.gnu.org/licenses/gpl-3.0.txt
https://www.gnu.org/licenses/lgpl-3.0.txt
https://www.mozilla.org/MPL/2.0/index.txt
