### PR TITLE
Fix runtime error when running with python 3

### DIFF
--- a/lice/core.py
+++ b/lice/core.py
@@ -131,7 +131,12 @@ def main():
                 sys.stderr.write("Sorry, no source headers are available for %s.\n" % args.license)
                 sys.exit(1)
 
-        content = generate_license(template.decode("UTF-8"), get_context(args))
+        # python 3 doesn't need UTF-8 decoding
+
+        if sys.version_info[0] < 3:
+            content = generate_license(template.decode("UTF-8"), get_context(args))
+        else:
+            content = generate_license(template, get_context(args))
         sys.stdout.write(content)
 
         sys.exit(0)


### PR DESCRIPTION
I was packaging it for Archlinux (python 3.3.2) and had a runtime error
because of the decode method, which was removed in favor of bytes.decode().

Since all strings are utf-8 by default in python 3, no decoding is needed.
