### PR TITLE
More languages

### DIFF
--- a/lice/core.py
+++ b/lice/core.py
@@ -46,7 +46,7 @@ LANGS = {"txt": "text", "h": "c", "hpp": "c", "c": "c", "cc": "c", "cpp": "c",
         "js": "c", "java": "java", "f": "fortran", "f90": "fortran90",
         "erl": "erlang", "html": "html", "css": "c", "m": "c",
         "hs": "haskell", "idr": "haskell", "clj": "lisp", "lisp": "lisp",
-        "agda": "haskell", "ml": "ml", "el": "lisp"}
+        "agda": "haskell", "ml": "ml", "el": "lisp", "php": "c"}
 
 LANG_CMT = {"text": [u'', u'', u''], "c": [u'/*', u' *', u' */'], "unix": [u'', u'#', u''],
         "lua": [u'--[[', u'', u'--]]'], "java": [u'/**', u' *', u' */'],


### PR DESCRIPTION
- Add some more languages (haskell, idris, clojure/lisp, agda, (s/oca)ml, php)
- Fix:

```
(_virtualenv)ricky@t520 /tmp/lice (master)$ lice -l php
Traceback (most recent call last):
  File "/tmp/lice/_virtualenv/bin/lice", line 9, in <module>
    load_entry_point('lice==0.4', 'console_scripts', 'lice')()
  File "/tmp/lice/_virtualenv/lib/python2.7/site-packages/lice-0.4-py2.7.egg/lice/__init__.py", line 6, in main
    main()
  File "/tmp/lice/_virtualenv/lib/python2.7/site-packages/lice-0.4-py2.7.egg/lice/core.py", line 271, in main
    out = format_license(content, lang)
  File "/tmp/lice/_virtualenv/lib/python2.7/site-packages/lice-0.4-py2.7.egg/lice/core.py", line 139, in format_license
    out.write(LANG_CMT[LANGS[lang]][0] + u'\n')
KeyError: 'php'
```
