### PR TITLE
[Feature] Add `scm` as an acceptable value for `--language`

### DIFF
--- a/lice/core.py
+++ b/lice/core.py
@@ -45,7 +45,7 @@ LANGS = {"txt": "text", "h": "c", "hpp": "c", "c": "c", "cc": "c", "cpp": "c",
         "py": "unix", "pl": "perl", "sh": "unix", "lua": "lua", "rb": "ruby",
         "js": "c", "java": "java", "f": "fortran", "f90": "fortran90",
         "erl": "erlang", "html": "html", "css": "c", "m": "c",
-        "hs": "haskell", "idr": "haskell", "clj": "lisp", "lisp": "lisp",
+        "hs": "haskell", "idr": "haskell", "clj": "lisp", "lisp": "lisp", "scm": "lisp",
         "agda": "haskell", "ml": "ml", "el": "lisp", "php": "c"}
 
 LANG_CMT = {"text": [u'', u'', u''], "c": [u'/*', u' *', u' */'], "unix": [u'', u'#', u''],


### PR DESCRIPTION
This is a simple convenience for using lice in conjunction with
software written in Scheme.  The output uses the same style of
comments produced by `--language lisp`.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>