### PR TITLE
Fix Python 3.12 compat: pkg_resources -> importlib

### DIFF
--- a/lice/core.py
+++ b/lice/core.py
@@ -1,4 +1,3 @@
-from pkg_resources import (resource_stream, resource_listdir)
 from io import StringIO
 import argparse
 import datetime
@@ -7,6 +6,21 @@ import os
 import subprocess
 import sys
 import getpass
+
+try:
+    from pkg_resources import resource_stream, resource_listdir
+except ImportError:
+    import importlib.resources
+
+    def resource_stream(package_or_requirement, resource_name):
+        # https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-stream
+        ref = importlib.resources.files(package_or_requirement).joinpath(resource_name)
+        return ref.open('rb')
+
+    def resource_listdir(package_or_requirement, resource_name):
+        # https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-listdir
+        resource_qualname = '.'.join([package_or_requirement, resource_name]).rstrip('.')
+        return [r.name for r in importlib.resources.files(resource_qualname).iterdir()]
 
 
 LICENSES = []

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     entry_points={
         'console_scripts': ['lice = lice:main']},
     platforms=['any'],
-    test_suite='lice.tests.collector',
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: BSD License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+env_list =
+    py311
+    py312
+minversion = 4.12.1
+
+[testenv]
+deps =
+    -r requirements.txt
+commands =
+    pytest {tty:--color=yes} {posargs}


### PR DESCRIPTION
```
Traceback (most recent call last):
  File ".../bin/lice", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File ".../lib/python3.12/site-packages/lice/__init__.py", line 5, in main
    from lice.core import main
  File ".../lib/python3.12/site-packages/lice/core.py", line 1, in <module>
    from pkg_resources import (resource_stream, resource_listdir)
ModuleNotFoundError: No module named 'pkg_resources'
```